### PR TITLE
(Improving Pull Request 1) Quoting Fixes

### DIFF
--- a/__bass.py
+++ b/__bass.py
@@ -24,11 +24,13 @@ def gen_script():
                        .check_output(['bash', '-c', command])
                        .split(divider, 1))
     new_env = new_env.lstrip().splitlines()
-
+    
+    new_env = [line for line in new_env if '{' not in line and '}' not in line]
+    
     old_env = dict([line.split('=', 1) for line in old_env])
     new_env = dict([line.split('=', 1) for line in new_env])
 
-    skips = ['PS1', 'SHLVL', 'XPC_SERVICE_NAME']
+    skips = ['PS1', 'SHLVL', 'XPC_SERVICE_NAME', 'PATH']
 
     with os.fdopen(fd, 'w') as f:
         for line in stdout.splitlines():
@@ -47,7 +49,7 @@ def gen_script():
                     continue
             else:
                 continue
-            f.write('set -g -x %s %s\n' % (k, v.replace(':', ' ')))
+            f.write('set -g -x %s "%s"\n' % (k, v))
 
     return name
 

--- a/__bass.py
+++ b/__bass.py
@@ -7,6 +7,7 @@ To be used with a companion fish function like this:
 
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -51,9 +52,12 @@ def gen_script():
             else:
                 continue
             if k == 'PATH':
-                value = v.replace(':', ' ')
+                # use json.dumps to reliably escape quotes and backslashes
+                value = ' '.join([json.dumps(directory)
+                                  for directory in v.split(':')])
             else:
-                value = '"%s"' % v.replace('"', '\"')
+                # use json.dumps to reliably escape quotes and backslashes
+                value = json.dumps(v)
             f.write('set -g -x %s %s\n' % (k, value))
 
     return name

--- a/__bass.py
+++ b/__bass.py
@@ -49,7 +49,7 @@ def gen_script():
                     continue
             else:
                 continue
-            f.write('set -g -x %s "%s"\n' % (k, v))
+            f.write('set -g -x %s "%s"\n' % (k, v.replace('"','\"')))
 
     return name
 

--- a/__bass.py
+++ b/__bass.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 
+
 def gen_script():
     fd, name = tempfile.mkstemp()
 
@@ -24,13 +25,13 @@ def gen_script():
                        .check_output(['bash', '-c', command])
                        .split(divider, 1))
     new_env = new_env.lstrip().splitlines()
-    
+
     new_env = [line for line in new_env if '{' not in line and '}' not in line]
-    
+
     old_env = dict([line.split('=', 1) for line in old_env])
     new_env = dict([line.split('=', 1) for line in new_env])
 
-    skips = ['PS1', 'SHLVL', 'XPC_SERVICE_NAME', 'PATH']
+    skips = ['PS1', 'SHLVL', 'XPC_SERVICE_NAME']
 
     with os.fdopen(fd, 'w') as f:
         for line in stdout.splitlines():
@@ -49,7 +50,11 @@ def gen_script():
                     continue
             else:
                 continue
-            f.write('set -g -x %s "%s"\n' % (k, v.replace('"','\"')))
+            if k == 'PATH':
+                value = v.replace(':', ' ')
+            else:
+                value = '"%s"' % v.replace('"', '\"')
+            f.write('set -g -x %s %s\n' % (k, value))
 
     return name
 


### PR DESCRIPTION
Fixes #3 

This PR is largely based on @junaid-shahid's #1. (Thanks, @junaid-shahid!) It fixes how variables are quoted/transformed when imported into fish. Specifically, we now only perform colon-separated-string-to-array translation for `PATH`. In addition, basic cleaning and quoting is added when writing variable values to the temporary fish script to be sourced.