### PR TITLE
Python script directory relative to `bass.fish`.

### DIFF
--- a/bass.fish
+++ b/bass.fish
@@ -6,7 +6,8 @@ function bass
     set __bash_args $argv
   end
 
-  set -l __script (python ~/.config/fish/functions/__bass.py $__bash_args)
+  set -l __script_dir (dirname (readlink -f (status --current-filename)))
+  set -l __script (python $__script_dir/__bass.py $__bash_args)
   if test $__script = '__error'
     echo "Bass encountered an error!"
   else


### PR DESCRIPTION
Determine Python script directory relatively to the `bass.fish' directory (currently they share the same directory) instead of hardcoding its location. This allows symbolic linking `bass.fish` in `~/.config/fish/functions` from anywhere.

My use case is: clone the `bass` git repository then create a symbolic link in `~/.config/fish/functions` from the cloned repository.