### PR TITLE
use '.' instead of source in bass.fish

### DIFF
--- a/bass.fish
+++ b/bass.fish
@@ -10,7 +10,7 @@ function bass
   if test $__script = '__error'
     echo "Bass encountered an error!"
   else
-    source $__script
+    . $__script
     if set -q __bass_debug
       cat $__script
     end


### PR DESCRIPTION
This patch addresses Issue #11 which I just filed.