### PR TITLE
Allow to override python function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ mynvm> function mynvm
 
 # Caveats
 
+## Interactive utilities
+
 At the moment, Bass does not work with interactive utilities. This is not hard
 to fix, but I cannot think of a use case. File a ticket if this is something
 you find missing.
+
+## Python 3
+
+If your `python` executable is Python 3, you will need to modify your configuration.
+Just add
+
+```
+function __bass_python; PATH_TO_PYTHON2 $argv; end
+```
+
+where `PATH_TO_PYTHON2` can be an absolute path or any executable on your path.

--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -6,7 +6,13 @@ function bass
     set __bash_args $argv
   end
 
-  set -l __script (python (dirname (status -f))/__bass.py $__bash_args)
+  if not functions -q __bass_python
+    function __bass_python
+      python $argv
+    end
+  end
+
+  set -l __script (__bass_python (dirname (status -f))/__bass.py $__bash_args)
   if test $__script = '__error'
     echo "Bass encountered an error!"
   else


### PR DESCRIPTION
On some OS, Python default version is 3 (ArchLinux for me).
As the Python script only works with Python 2, I thought it would be a good idea
to allow the user to be able to decide what Python should be used.

With this approach, users who do not need to customize this do not have to do anything,
and those who need to customize just need to add

```
function __bass_python; python2 $argv; end
```

in their config and that's it.