### PR TITLE
Fix Python 3 compatibility.

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -23,7 +23,7 @@ def gen_script():
 
     # Use the following instead of /usr/bin/env to read environment so we can
     # deal with multi-line environment variables (and other odd cases).
-    env_reader = "python -c 'import os,json; print json.dumps({k:v for k,v in os.environ.iteritems()})'"
+    env_reader = "python -c 'import os,json; print(json.dumps({k:v for k,v in os.environ.items()}))'"
     args = [BASH, '-c', env_reader]
     output = subprocess.check_output(args, universal_newlines=True)
     old_env = output.strip()


### PR DESCRIPTION
As discussed in #18, the script was breaking on Python 3, so I fixed it to be compatible with both 2 and 3.
The `env_reader` added in #16 seemed to cause the issue.