### PR TITLE
Add `all` target and Fisherman installation note.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+all:
+	@echo "Run 'make install' to deploy bass to your function directory."
+
 install:
 	install -d ~/.config/fish/functions
 	install functions/__bass.py ~/.config/fish/functions

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Use the Makefile.
 
 Relaunch the shell for the change to take effect.
 
+## Using [Fisherman](https://github.com/fisherman/fisherman)
+
+```fish
+fisher install bass
+```
+
 ## Using [fundle](https://github.com/tuvistavie/fundle)
 
 Add


### PR DESCRIPTION
In the current implementation, running `make` will run `make install` by default causing [Fisherman](http://fisherman.sh) to deploy bass to ~/.config/fish/functions when it should not.

Even if Fisherman was able to patch this for the specific case of bass, it seems like a good practice to separate the build and install steps.

tl;dr

+ This PR does not break the compatibility with either `fundle` or the recommended installation method described in the README. 

+ Add compatibility to Fisherman and add note in README with install instructions using Fisherman.