### PR TITLE
Update README.md to include --no-use flag for nvm function

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can then very easily pack the command as a function and feel more at home:
 ```
 > funced mynvm
 mynvm> function mynvm
-           bass source ~/.nvm/nvm.sh ';' nvm $argv
+           bass source ~/.nvm/nvm.sh --no-use ';' nvm $argv
        end
 
 > mynvm list


### PR DESCRIPTION
Currently, the `nvm` example in the `README.md` file does not include the `--no-use` parameter when sourcing `nvm`. This leads to issues on subsequent calls if you have the `default` alias set. Each call to the function will reset the Node version back to `default`.

Including the `--no-use` flag prevents nvm from resetting the current version so that the fish `nvm` function will perform as expected.