### PR TITLE
Don't copy exported bash functions

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -42,8 +42,6 @@ def gen_script():
     old_env = json.loads(old_env)
     new_env = json.loads(new_env)
 
-    skips = ['PS1', 'SHLVL', 'XPC_SERVICE_NAME']
-
     script_lines = []
 
     for line in stdout.splitlines():
@@ -51,7 +49,7 @@ def gen_script():
         line = line.replace(r'$', r'\$')
         script_lines.append("printf %s;printf '\\n'" % json.dumps(line))
     for k, v in new_env.items():
-        if k in skips:
+        if k in ['PS1', 'SHLVL', 'XPC_SERVICE_NAME'] or k.startswith("BASH_FUNC"):
             continue
         v1 = old_env.get(k)
         if not v1:


### PR DESCRIPTION
I noticed that if you use bass to run a bash script like the following:

```bash
function foo() {
  local bar="baz"
  echo $bar
}

export -f foo
```

The bash function gets loaded into `new_env` with a key like `BASH_FUNC_foo%%` and the value is a string of Bash source code like `() { local bar="baz"; echo $bar }`.

So bass puts a line like the following into the Fish script:

```fish
set -g -x BASH_FUNC_foo%% "() { local bar="baz"; echo $bar }"
```

This fails when the script is executed for two reasons:

- `%` is not a valid character for a variable name in Fish.
- Fish tries to interpolate `$` values in the string of Bash source code.

I don't think it makes any sense to copy exported Bash functions, so this PR makes it so that we skip them.