### PR TITLE
Exit with error code

### DIFF
--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -10,6 +10,7 @@ function bass
     echo "Usage: bass [-d] <bash-command>"
   else if test "$__script" = '__error'
     echo "Bass encountered an error!"
+    return 1
   else
     echo -e "$__script" | source -
     if set -q __bass_debug


### PR DESCRIPTION
Bass says an error occurred but exits with status code of 0

Making it harder to rely on the exit status when bass encounters an error.

Actual: 
<img width="218" alt="screen shot 2018-01-04 at 15 08 03" src="https://user-images.githubusercontent.com/2544673/34570162-e2347464-f162-11e7-8ef0-c5cbdb447261.png">

After this PR
<img width="236" alt="screen shot 2018-01-04 at 15 08 27" src="https://user-images.githubusercontent.com/2544673/34570167-e68d69da-f162-11e7-9483-b7c5f09175da.png">


