### PR TITLE
Strip trailing semicolons from arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,6 @@ uninstall:
 test:
 	fish test/test_bass.fish
 	fish test/test_dollar_on_output.fish
+	fish test/test_trailing_semicolon.fish
 
 .PHONY: test

--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -31,7 +31,7 @@ def gen_script():
     old_env = output.strip()
 
     command = '{} && (echo "{}"; {}; echo "{}"; alias)'.format(
-        ' '.join(sys.argv[1:]),
+        ' '.join(sys.argv[1:]).rstrip().rstrip(';'),
         divider,
         env_reader,
         divider,

--- a/test/fixtures/trailing_semicolon.sh
+++ b/test/fixtures/trailing_semicolon.sh
@@ -1,0 +1,5 @@
+function trailing_semicolon() {
+	echo 'export SEMICOLON_RSTRIPPED=1;'
+}
+
+trailing_semicolon

--- a/test/test_trailing_semicolon.fish
+++ b/test/test_trailing_semicolon.fish
@@ -1,0 +1,7 @@
+set root (dirname (dirname (status -f)))
+source $root/functions/bass.fish
+
+bass (sh $root/test/fixtures/trailing_semicolon.sh)
+and if [ "$SEMICOLON_RSTRIPPED" = "1" ]
+	echo 'Success'
+end


### PR DESCRIPTION
Execution of 'bass (ssh-agent)' fails because of a trailing
semicolon at the end of ssh-agent's output, so trim it.