### PR TITLE
Use absolute path for the .py file

### DIFF
--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -5,7 +5,15 @@ function bass
     set -e __bash_args[1]
   end
 
-  python (dirname (status -f))/__bass.py $__bash_args | read -z __script
+  if test -L (status -f)
+    set __bass_path (dirname (realpath (status -f)))
+    echo $__bass_path
+  else
+    set __bass_path  (dirname (status -f))
+  end
+
+  python $__bass_path/__bass.py $__bash_args | read -z __script
+
   if test "$__script" = '__usage'
     echo "Usage: bass [-d] <bash-command>"
   else if test "$__script" = '__error'


### PR DESCRIPTION
The new version of fisher v3 only symlinks `.fish` files, I have added a check, to see if the bass is a symlink, if so, get the original path.

This way we don't need to symlink `.py` files inside `fish/functions/`