### PR TITLE
Fully support interactive commands that use stdout

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import traceback
@@ -95,5 +96,8 @@ except subprocess.CalledProcessError as e:
 except Exception:
     print('Bass internal error!', file=sys.stderr)
     raise # traceback will output to stderr
+except KeyboardInterrupt:
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    os.kill(os.getpid(), signal.SIGINT)
 else:
     script_file.write(script)

--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -10,6 +10,7 @@ To be used with a companion fish function like this:
 from __future__ import print_function
 
 import json
+import os
 import subprocess
 import sys
 import traceback
@@ -25,8 +26,6 @@ def comment(string):
     return '\n'.join(['# ' + line for line in string.split('\n')])
 
 def gen_script():
-    divider = '-__-__-__bass___-env-output-__bass_-__-__-__-__'
-
     # Use the following instead of /usr/bin/env to read environment so we can
     # deal with multi-line environment variables (and other odd cases).
     env_reader = "python -c 'import os,json; print(json.dumps({k:v for k,v in os.environ.items()}))'"
@@ -34,15 +33,20 @@ def gen_script():
     output = subprocess.check_output(args, universal_newlines=True)
     old_env = output.strip()
 
-    command = '{}\n(echo "{}"; {}; echo "{}"; alias)'.format(
+    pipe_r, pipe_w = os.pipe()
+    if sys.version_info >= (3, 4):
+      os.set_inheritable(pipe_w, True)
+    command = '{}\n({}; alias) >&{}'.format(
         ' '.join(sys.argv[1:]).rstrip().rstrip(';'),
-        divider,
         env_reader,
-        divider,
+        pipe_w
     )
     args = [BASH, '-c', command]
-    output = subprocess.check_output(args, universal_newlines=True)
-    stdout, new_env, alias = output.split(divider, 2)
+    subprocess.check_call(args, universal_newlines=True, close_fds=False)
+    os.close(pipe_w)
+    with os.fdopen(pipe_r) as f:
+        new_env = f.readline()
+        alias = f.read()
     new_env = new_env.strip()
 
     old_env = json.loads(old_env)
@@ -50,9 +54,6 @@ def gen_script():
 
     script_lines = []
 
-    for line in stdout.splitlines():
-        # some outputs might use documentation about the shell usage with dollar signs
-        script_lines.append("printf %s;printf '\\n'" % escape(line))
     for k, v in new_env.items():
         if k in ['PS1', 'SHLVL', 'XPC_SERVICE_NAME'] or k.startswith("BASH_FUNC"):
             continue
@@ -82,18 +83,18 @@ def gen_script():
 
     return script + '\n' + alias
 
+script_file = os.fdopen(3, 'w')
+
 if not sys.argv[1:]:
-    print('__usage', end='')
+    print('__bass_usage', file=script_file, end='')
     sys.exit(0)
 
 try:
     script = gen_script()
 except subprocess.CalledProcessError as e:
-    print('exit code:', e.returncode, file=sys.stderr)
-    print('__error', e.returncode, end='')
-except Exception as e:
-    print('unknown error:', str(e), file=sys.stderr)
-    traceback.print_exc(10, file=sys.stderr)
-    print('__error', end='')
+    sys.exit(e.returncode)
+except Exception:
+    print('Bass internal error!', file=sys.stderr)
+    raise # traceback will output to stderr
 else:
-    print(script, end='')
+    script_file.write(script)

--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -36,12 +36,11 @@ def gen_script():
     pipe_r, pipe_w = os.pipe()
     if sys.version_info >= (3, 4):
       os.set_inheritable(pipe_w, True)
-    command = '{}\n({}; alias) >&{}'.format(
-        ' '.join(sys.argv[1:]).rstrip().rstrip(';'),
+    command = 'eval $1 && ({}; alias) >&{}'.format(
         env_reader,
         pipe_w
     )
-    args = [BASH, '-c', command]
+    args = [BASH, '-c', command, 'bass', ' '.join(sys.argv[1:])]
     subprocess.check_call(args, universal_newlines=True, close_fds=False)
     os.close(pipe_w)
     with os.fdopen(pipe_r) as f:

--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -1,27 +1,25 @@
 function bass
-  set __bash_args $argv
-  if test "$__bash_args[1]_" = '-d_'
-    set __bass_debug
-    set -e __bash_args[1]
+  set -l bash_args $argv
+  set -l bass_debug
+  if test "$bash_args[1]_" = '-d_'
+    set bass_debug true
+    set -e bash_args[1]
   end
 
-  python (dirname (status -f))/__bass.py $__bash_args | read -z __script
-  set __errorflag (string sub -s 1 -l 7 "$__script")
-  if test "$__script" = '__usage'
-    echo "Usage: bass [-d] <bash-command>"
-  else if test "x$__errorflag" = 'x__error'
-    echo "Bass encountered an error!"
-    set __exitcode (string sub -s 9 "$__script")
-    set __exitcode (string trim $__exitcode)
-    if test -z $__exitcode
-      return 1
-    else
-      return $__exitcode
-    end
-  else
-    echo -e "$__script" | source -
-    if set -q __bass_debug
-      echo "$__script"
-    end
+  set -l script_file (mktemp)
+  python (dirname (status -f))/__bass.py $bash_args 3>$script_file
+  set -l bass_status $status
+  if test $bass_status -ne 0
+    return $bass_status
   end
+
+  if test -n "$bass_debug"
+    cat $script_file
+  end
+  source $script_file
+  rm $script_file
+end
+
+function __bass_usage
+  echo "Usage: bass [-d] <bash-command>"
 end


### PR DESCRIPTION
The environment and aliases are outputted from bash on a pipe, and the script is outputted on FD 3. This leaves bash with full control over stdio. Bass will now only write to stdio if there's a Python exception.

This also simplifies the code. Since there's no need to handle stdout specially, the environment is just the first line of the output from bash, which means there's no need for a divider anymore.

The fish code has been refactored to use local variables and propagate exit statuses more sanely.