### PR TITLE
Ignore read-only variables

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -19,6 +19,25 @@ import traceback
 
 BASH = 'bash'
 
+FISH_READONLY = [
+    'PWD', 'SHLVL', 'history', 'pipestatus', 'status', 'version',
+    'FISH_VERSION', 'fish_pid', 'hostname', '_', 'fish_private_mode'
+]
+
+IGNORED = [
+ 'PS1', 'XPC_SERVICE_NAME'
+]
+
+def ignored(name):
+    if name == 'PWD':  # this is read only, but has special handling
+        return False
+    # ignore other read only variables
+    if name in FISH_READONLY:
+        return True
+    if name in IGNORED or name.startswith("BASH_FUNC"):
+        return True
+    return False
+
 def escape(string):
     # use json.dumps to reliably escape quotes and backslashes
     return json.dumps(string).replace(r'$', r'\$')
@@ -55,7 +74,7 @@ def gen_script():
     script_lines = []
 
     for k, v in new_env.items():
-        if k in ['PS1', 'SHLVL', 'XPC_SERVICE_NAME'] or k.startswith("BASH_FUNC"):
+        if ignored(k):
             continue
         v1 = old_env.get(k)
         if not v1:


### PR DESCRIPTION
These variables [cannot be set in fish](
https://github.com/fish-shell/fish-shell/blob/7f59a7e7cfd2d49d8df3d652ff1e1b8a0b1527bc/src/env.cpp#L83-L96):

* `PWD`
* `SHLVL`
* `history`
* `pipestatus`
* `status`
* `version`
* `FISH_VERSION`
* `fish_pid`
* `hostname`
* `_`
* `fish_private_mode`

If a script exports this variable an error message `bass` should not try and set them in fish because this error message will be emitted:

    set: Tried to change the read-only variable “_”

In this case it's particularly annoying becausethe underscore variable is [automatically set by bash](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html#Special-Parameters):
> Also set to the full pathname used to invoke each command executed and placed in the environment exported to that command.