### PR TITLE
Fix NixOS support

### DIFF
--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -7,7 +7,11 @@ function bass
   end
 
   set -l script_file (mktemp)
-  python (dirname (status -f))/__bass.py $bash_args 3>$script_file
+  set -l python "python"
+  if command -v python3 >/dev/null 2>&1
+      set python "python3"
+  end
+  command $python (dirname (status -f))/__bass.py $bash_args 3>$script_file
   set -l bass_status $status
   if test $bass_status -ne 0
     return $bass_status

--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -21,7 +21,7 @@ function bass
     cat $script_file
   end
   source $script_file
-  /bin/rm $script_file
+  command rm $script_file
 end
 
 function __bass_usage


### PR DESCRIPTION
This commit https://github.com/edc/bass/commit/4beb35458cfcccef080b9764c97f928e149dca49 changed `rm` to `/bin/rm` in order to avoid using a user-defined alias. It's better to use something like Fish's `command` builtin to ignore aliases, instead of assuming something is present at an absolute path.

NixOS is an operating system where `/bin/rm` is not available, so this fixes support on NixOS.

I also made the `bass` function try to use a more specific `python` executable such as `python3` to avoid assuming the `python` executable is Python 3 and not Python 2.