### PR TITLE
Use the same Python interpreter for subprocesses as was used to invoke the script.

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -48,7 +48,7 @@ def comment(string):
 def gen_script():
     # Use the following instead of /usr/bin/env to read environment so we can
     # deal with multi-line environment variables (and other odd cases).
-    env_reader = "python -c 'import os,json; print(json.dumps({k:v for k,v in os.environ.items()}))'"
+    env_reader = "%s -c 'import os,json; print(json.dumps({k:v for k,v in os.environ.items()}))'" % (sys.executable)
     args = [BASH, '-c', env_reader]
     output = subprocess.check_output(args, universal_newlines=True)
     old_env = output.strip()


### PR DESCRIPTION
In particular, if  was used to invoke the script, then it should used  for its subprocess execution, otherwise it may pick up Python 2 or fail if there is no  command available (see PEP 394).