### PR TITLE
Improve startup speed by running Python with `-sS`

### DIFF
--- a/functions/bass.fish
+++ b/functions/bass.fish
@@ -8,9 +8,9 @@ function bass
 
   set -l script_file (mktemp)
   if command -v python3 >/dev/null 2>&1
-    command python3 (dirname (status -f))/__bass.py $bash_args 3>$script_file
+    command python3 -sS (dirname (status -f))/__bass.py $bash_args 3>$script_file
   else
-    command python (dirname (status -f))/__bass.py $bash_args 3>$script_file
+    command python -sS (dirname (status -f))/__bass.py $bash_args 3>$script_file
   end
   set -l bass_status $status
   if test $bass_status -ne 0


### PR DESCRIPTION
This patch improves startup speed by disabling Python's `site` module:

```
-s     Don't add user site directory to sys.path.

-S     Disable the import of the module site and  the  site-dependent
       manipulations of sys.path that it entails.
```

Benchmarked with [hyperfine](https://github.com/sharkdp/hyperfine), comparing `bass` installed with fisher to this patch:

```
hyperfine -S fish 'bass echo hello' 'source functions/bass.fish; bass echo hello' --export-markdown t.md
```

| Command                                       | Mean [ms]    | Min [ms] | Max [ms] | Relative    |
|:----------------------------------------------|-------------:|---------:|---------:|------------:|
| `bass echo hello`                             | 140.2 ± 16.6 | 125.3    | 187.5    | 1.06 ± 0.14 |
| `source functions/bass.fish; bass echo hello` | 131.7 ± 6.2  | 122.4    | 142.1    | 1.00        |
