### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ omf install bass
 ## With [Fisher](https://github.com/jorgebucaran/fisher)
 
 ```console
-fisher install edc/bass
+fisher add edc/bass
 ```
 
 ## With [Fundle](https://github.com/tuvistavie/fundle)


### PR DESCRIPTION
Fisher is using `add` instead of `install`, fisher version 3.2.11

```
fisher: unknown flag or command "install"
usage: fisher add <package...>     Add packages
       fisher rm  <package...>     Remove packages
       fisher                      Update all packages
       fisher ls  [<regex>]        List installed packages matching <regex>
       fisher --help               Show this help
       fisher --version            Show the current version
       fisher self-update          Update to the latest version
       fisher self-uninstall       Uninstall from your system
```