### PR TITLE
Shift $1 out prior to eval

### DIFF
--- a/functions/__bass.py
+++ b/functions/__bass.py
@@ -59,7 +59,7 @@ def gen_script():
     pipe_r, pipe_w = os.pipe()
     if sys.version_info >= (3, 4):
       os.set_inheritable(pipe_w, True)
-    command = 'eval $1 && ({}; alias) >&{}'.format(
+    command = 'bass_args=$1; shift; eval $bass_args && ({}; alias) >&{}'.format(
         env_reader,
         pipe_w
     )


### PR DESCRIPTION
Shift the first positional parameter out into a variable before running the eval command, so that it is not passed onto sourced scripts.

Fixes #89 