### PR TITLE
Correct installation permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all:
 
 install:
 	install -d ~/.config/fish/functions
-	install functions/__bass.py ~/.config/fish/functions
-	install functions/bass.fish ~/.config/fish/functions
+	install -m644 functions/__bass.py ~/.config/fish/functions
+	install -m644 functions/bass.fish ~/.config/fish/functions
 
 uninstall:
 	rm -f ~/.config/fish/functions/__bass.py


### PR DESCRIPTION
There is no need for Fish functions to have execution permission on. Thus, this minor change assures the copied files have sufficient permissions to run, and no more.